### PR TITLE
[ESN-2170]CHHS Email Amendments

### DIFF
--- a/ckanext/subscribe/controller.py
+++ b/ckanext/subscribe/controller.py
@@ -74,8 +74,9 @@ class SubscribeController(BaseController):
         else:
             subscribe_title = dataset_title or group_title
             h.flash_success(
-                _('Subscription to {} was successful, please confirm '
-                    'your subscription by checking your email inbox and spam/trash folder'.format(subscribe_title)))
+                _('Subscription to "{}" was successful, please confirm '
+                    'your subscription by checking your email inbox and '
+                    'spam/trash folder'.format(subscribe_title)))
 
             return self._redirect_back_to_subscribe_page(
                 subscription['object_name'], subscription['object_type'])

--- a/ckanext/subscribe/controller.py
+++ b/ckanext/subscribe/controller.py
@@ -29,6 +29,8 @@ class SubscribeController(BaseController):
     def signup(self):
         # validate inputs
         email = request.POST.get('email')
+        dataset_title = request.POST.get('dataset-title')
+        group_title = request.POST.get('group-title')
         if not email:
             abort(400, _(u'No email address supplied'))
         email = email.strip()
@@ -70,9 +72,14 @@ class SubscribeController(BaseController):
                             'administrator for help'))
             return self._redirect_back_to_subscribe_page_from_request(data_dict)
         else:
-            h.flash_success(
-                _('Subscription requested. Please confirm, by clicking in the '
-                  'link in the email just sent to you'))
+            if dataset_title:
+                h.flash_success(
+                    _('Subscription to {} was successful, please confirm '
+                      'your subscription by checking your email inbox and spam/trash folder'.format(dataset_title)))
+            else:
+                h.flash_success(
+                    _('Subscription to {} was successful, please confirm '
+                      'your subscription by checking your email inbox and spam/trash folder'.format(group_title)))
             return self._redirect_back_to_subscribe_page(
                 subscription['object_name'], subscription['object_type'])
 

--- a/ckanext/subscribe/controller.py
+++ b/ckanext/subscribe/controller.py
@@ -74,9 +74,10 @@ class SubscribeController(BaseController):
         else:
             subscribe_title = dataset_title or group_title
             h.flash_success(
-                _('Subscription to "{}" was successful, please confirm '
-                    'your subscription by checking your email inbox and '
-                    'spam/trash folder'.format(subscribe_title)))
+                _('Subscription to {} was successful, please confirm '
+                  'your subscription by checking your email inbox and '
+                  'spam/trash folder'.format(subscribe_title))
+            )
 
             return self._redirect_back_to_subscribe_page(
                 subscription['object_name'], subscription['object_type'])

--- a/ckanext/subscribe/controller.py
+++ b/ckanext/subscribe/controller.py
@@ -72,14 +72,11 @@ class SubscribeController(BaseController):
                             'administrator for help'))
             return self._redirect_back_to_subscribe_page_from_request(data_dict)
         else:
-            if dataset_title:
-                h.flash_success(
-                    _('Subscription to {} was successful, please confirm '
-                      'your subscription by checking your email inbox and spam/trash folder'.format(dataset_title)))
-            else:
-                h.flash_success(
-                    _('Subscription to {} was successful, please confirm '
-                      'your subscription by checking your email inbox and spam/trash folder'.format(group_title)))
+            subscribe_title = dataset_title or group_title
+            h.flash_success(
+                _('Subscription to {} was successful, please confirm '
+                    'your subscription by checking your email inbox and spam/trash folder'.format(subscribe_title)))
+
             return self._redirect_back_to_subscribe_page(
                 subscription['object_name'], subscription['object_type'])
 

--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -16,11 +16,11 @@
     display: block;
     margin-bottom: 5px;
     padding: 6px 6px 6px 6px;
-    width: auto;
+    width: -webkit-fill-available;
 }
 
 #subscribe-form .btn {
-    width: 100%;
+    width: -webkit-fill-available;
     display: block;
     margin-left: 0px;
 }

--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -13,7 +13,16 @@
     margin-bottom: 5px;
 }
 #subscribe-form input {
-    width: 90px;
+    display: block;
+    margin-bottom: 5px;
+    padding: 6px 6px 6px 6px;
+    width: auto;
+}
+
+#subscribe-form .btn {
+    width: 100%;
+    display: block;
+    margin-left: 0px;
 }
 
 /* manage page */

--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -16,10 +16,14 @@
     display: block;
     margin-bottom: 5px;
     padding: 6px 6px 6px 6px;
+    width: auto;
+    width: -moz-available;
     width: -webkit-fill-available;
 }
 
 #subscribe-form .btn {
+    width: auto;
+    width: -moz-available;
     width: -webkit-fill-available;
     display: block;
     margin-left: 0px;

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -22,10 +22,11 @@
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="" />
+          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" />
           <input id="subscribe-group" type="hidden" name="group" value="{{ group.name }}"` />
+          <input id="subscribe-group-title" type="hidden" name="group-title" value="{{ group.title }}"` />
         <!-- </div> -->
-        <button type="submit" class="btn btn-default" name="save">{{ _('Submit') }}</button>
+        <button type="submit"  class="btn btn-primary round-corner-btn" name="save">{{ _('Subscribe Now') }}</button>
       </form>
     </div>
   {% endif %}

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -22,7 +22,7 @@
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" />
+          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" required />
           <input id="subscribe-group" type="hidden" name="group" value="{{ group.name }}"` />
           <input id="subscribe-group-title" type="hidden" name="group-title" value="{{ group.title }}"` />
         <!-- </div> -->

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -22,7 +22,7 @@
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" />
+          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address"  required />
           <input id="subscribe-dataset" type="hidden" name="dataset" value="{{ pkg.name }}"` />
           <input id="subscribe-dataset-title" type="hidden" name="dataset-title" value="{{ pkg.title }}"` />
         <!-- </div> -->

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -22,10 +22,11 @@
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="" />
+          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" />
           <input id="subscribe-dataset" type="hidden" name="dataset" value="{{ pkg.name }}"` />
+          <input id="subscribe-dataset-title" type="hidden" name="dataset-title" value="{{ pkg.title }}"` />
         <!-- </div> -->
-        <button type="submit" class="btn btn-default" name="save">{{ _('Submit') }}</button>
+        <button type="submit" class="btn btn-primary round-corner-btn" name="save">{{ _('Subscribe Now') }}</button>
       </form>
     </div>
   {% endif %}

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -22,10 +22,11 @@
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="" />
+          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" />
           <input id="subscribe-group" type="hidden" name="group" value="{{ organization.name }}"` />
+          <input id="subscribe-group-title" type="hidden" name="group-title" value="{{ organization.title }}"` />
         <!-- </div> -->
-        <button type="submit" class="btn btn-default" name="save">{{ _('Submit') }}</button>
+        <button type="submit" class="btn btn-primary round-corner-btn" name="save">{{ _('Subscribe Now') }}</button>
       </form>
     </div>
   {% endif %}

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -22,7 +22,7 @@
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" />
+          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" required />
           <input id="subscribe-group" type="hidden" name="group" value="{{ organization.name }}"` />
           <input id="subscribe-group-title" type="hidden" name="group-title" value="{{ organization.title }}"` />
         <!-- </div> -->


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-2170](https://opengovinc.atlassian.net/browse/ESN-2170)

## Description
<!--- Describe these changes in detail --->
This PR updates the the UI experience of the subscribe extension. The input and submit button match the length of the container it is in along with the submit button using the CHHS colors. 

Lastly, the display message when subscribing has been updated to include the dataset/organization/group in the message. This was done by passing the title through the form input in the POST request and using it in the controller class in the `signup` function.

## Test Procedure
<!--- List the steps involved to test the changes --->
**UI Testing**
1. Checkout the branch for this PR and run `python setup.py develop`
2. In your ini:
 - Enable the following plugins
```
spatial_metadata
spatial_query
chhs_schema
scheming_datasets
composite
repeating
```
3. Checkout the `chhs` branch in `ckanext-og_theme` and run `python setup.py develop`.
4. Visit the following pages NOT logged into the Open Data portal:
 - Any dataset page
 - Any group's page
 - Any organization's
and ensure you see the updated subscription UI (in ticket).
5. Subscribe to the dataset/organization/group and ensure the success message says “Subscription to [Dataset/Group/Organization TITLE] was successful, please confirm your subscription by checking your email inbox and spam/trash folder.”

Acceptance Criteria:
- Input field for email should span the length of the container.
- Input field should have a label – preferably as a placeholder within the text field.
- “Submit” button should be below the email input field.
- “Submit” button text should be an active tense – “Subscribe Now”.
- “Submit” button color should use CHHS palette. (#379ed8)
- Success message when subscribing to a page displays : “Subscription to [INSERT DATASET TITLE] was successful, please confirm your subscription by checking your email inbox and spam/trash folder.”