### PR TITLE
[ESN-2170] Update CSS based on CHHS Feedback

### DIFF
--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -10,28 +10,26 @@
     }
 }
 
-div#subscribe-module-info {
-    margin-top: 0px;
+#subscribe-form {
+    margin: 0 0 5px;
 }
-
 #subscribe-form .control-label {
     margin-bottom: 5px;
 }
 #subscribe-form input {
     display: block;
-    margin-bottom: 5px;
-    padding: 6px 6px 6px 6px;
+    margin-bottom: 10px;
+    padding: 4px 6px;
     width: auto;
     width: -moz-available;
     width: -webkit-fill-available;
 }
-
 #subscribe-form .btn {
     width: auto;
     width: -moz-available;
     width: -webkit-fill-available;
     display: block;
-    margin-left: 0px;
+    margin-left: 0;
 }
 
 /* manage page */

--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -10,7 +10,7 @@
     }
 }
 
-div#subscribe-title {
+div#subscribe-module-info {
     margin-top: 0px;
 }
 

--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -14,7 +14,7 @@
 }
 #subscribe-form input {
     display: block;
-    margin-bottom: 5px;
+    margin-bottom: 10px;
     padding: 6px 6px 6px 6px;
     width: auto;
     width: -moz-available;
@@ -28,6 +28,18 @@
     display: block;
     margin-left: 0px;
 }
+
+.context-info .module-content {
+    padding: 15px;
+    padding-bottom: 0px;
+}
+
+.subscribe-nums {
+    *zoom: 1;
+    padding-top: 10px;
+    padding-bottom: 0;
+    border-top: 1px dotted #DDD;
+}   
 
 /* manage page */
 table#subscriptions {

--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -9,12 +9,17 @@
         margin-left: 0;
     }
 }
+
+div#subscribe-title {
+    margin-top: 0px;
+}
+
 #subscribe-form .control-label {
     margin-bottom: 5px;
 }
 #subscribe-form input {
     display: block;
-    margin-bottom: 10px;
+    margin-bottom: 5px;
     padding: 6px 6px 6px 6px;
     width: auto;
     width: -moz-available;
@@ -28,18 +33,6 @@
     display: block;
     margin-left: 0px;
 }
-
-.context-info .module-content {
-    padding: 15px;
-    padding-bottom: 0px;
-}
-
-.subscribe-nums {
-    *zoom: 1;
-    padding-top: 10px;
-    padding-bottom: 0;
-    border-top: 1px dotted #DDD;
-}   
 
 /* manage page */
 table#subscriptions {

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -16,7 +16,7 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="subscribe-nums">
+    <div class="nums" id="subscribe-title">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -16,7 +16,7 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="nums" id="subscribe-title">
+    <div class="nums" id="subscribe-module-info">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -16,7 +16,7 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="nums" id="subscribe-module-info">
+    <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -16,7 +16,7 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="nums">
+    <div class="subscribe-nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -16,7 +16,7 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="subscribe-nums">
+    <div class="nums" id="subscribe-title">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -16,7 +16,7 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="nums" id="subscribe-title">
+    <div class="nums" id="subscribe-module-info">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -16,7 +16,7 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="nums">
+    <div class="subscribe-nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -16,13 +16,13 @@
     {{ super() }}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
-    <div class="nums" id="subscribe-module-info">
+    <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
-          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address"  required />
+          <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" required />
           <input id="subscribe-dataset" type="hidden" name="dataset" value="{{ pkg.name }}"` />
           <input id="subscribe-dataset-title" type="hidden" name="dataset-title" value="{{ pkg.title }}"` />
         <!-- </div> -->


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-2170](https://opengovinc.atlassian.net/browse/ESN-2170)

## Description
<!--- Describe these changes in detail --->
This PR updates the CSS of the dataset page and group/org page based on feedback from CHHS. The feedback includes to reduce the space between the name of dataset/group/org and the subscribe form and to reduce the space between the subscribe form and the tile under.

## Test Procedure
<!--- List the steps involved to test the changes --->
**UI Testing**
1. Checkout the branch for this PR and run `python setup.py develop`
2. In your ini:
 - Enable the following plugins
```
spatial_metadata
spatial_query
chhs_schema
scheming_datasets
```
3. Checkout the `chhs` branch in `ckanext-og_theme` and run `python setup.py develop`.
4. Visit the following pages NOT LOGGED into the Open Data portal:
 - Any dataset page
 - Any group's page
 - Any organization's
and ensure you the page looks like the following screenshots.

### Old Dataset Subscribe Tile
![Screen Shot 2021-03-24 at 6 39 20 PM](https://user-images.githubusercontent.com/49450112/112392976-b1435c00-8cd0-11eb-843b-595939eaa7f8.png)


### New Dataset Subscribe Tile
![Screen Shot 2021-03-24 at 6 39 15 PM](https://user-images.githubusercontent.com/49450112/112392888-8eb14300-8cd0-11eb-8eaa-da38859bad85.png)


### Old Org/Group Subscribe Tile
![Screen Shot 2021-03-24 at 6 39 54 PM](https://user-images.githubusercontent.com/49450112/112392927-9d97f580-8cd0-11eb-83f3-2ef44dfec1a9.png)

### New Org/Group Subscribe Tile
![Screen Shot 2021-03-24 at 6 39 44 PM](https://user-images.githubusercontent.com/49450112/112392885-8bb65280-8cd0-11eb-9ceb-d9de0a2f32e5.png)