### PR TITLE
[ESN-2170] Update CSS based on CHHS Feedback

### DIFF
--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -47,7 +47,3 @@ table#subscriptions {
 #subscriptions select#frequency {
     width: 120px;
 }
-
-label::after {
-    content: "";
-}

--- a/ckanext/subscribe/fanstatic/subscribe.css
+++ b/ckanext/subscribe/fanstatic/subscribe.css
@@ -47,3 +47,7 @@ table#subscriptions {
 #subscriptions select#frequency {
     width: 120px;
 }
+
+label::after {
+    content: "";
+}

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -19,16 +19,17 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label" for="subscribe-email" title="Receive email updates for this group without needing to login." aria-label="Receive email updates for this group without needing to login.">
-        {{ _('Sign up for email updates') }}
-      </label>
+      <label class="control-label"
+             for="subscribe-email"
+             title="Receive email updates for this group without needing to login."
+             aria-label="Receive email updates for this group without needing to login.">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
           <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" required />
           <input id="subscribe-group" type="hidden" name="group" value="{{ group.name }}"` />
           <input id="subscribe-group-title" type="hidden" name="group-title" value="{{ group.title }}"` />
         <!-- </div> -->
-        <button type="submit"  class="btn btn-primary round-corner-btn" name="save">{{ _('Subscribe Now') }}</button>
+        <button type="submit" class="btn btn-primary round-corner-btn" name="save">{{ _('Subscribe Now') }}</button>
       </form>
     </div>
   {% endif %}

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -20,7 +20,7 @@
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label subscribe-label" for="subscribe-email">
-        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this group or log in and follow this dataset." data-toggle="tooltip"></i>
+        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this group or log in to follow." data-toggle="tooltip"></i>
         {{ _('Sign up for email updates:') }}
       </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -19,9 +19,8 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label subscribe-label" for="subscribe-email">
-        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this group or log in to follow." data-toggle="tooltip"></i>
-        {{ _('Sign up for email updates:') }}
+      <label class="control-label" for="subscribe-email" title="Receive email updates for this group without needing to login." aria-label="Receive email updates for this group without needing to login.">
+        {{ _('Sign up for email updates') }}
       </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -19,7 +19,10 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
+      <label class="control-label subscribe-label" for="subscribe-email">
+        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this group or log in and follow this dataset." data-toggle="tooltip"></i>
+        {{ _('Sign up for email updates:') }}
+      </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
           <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" required />

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -19,7 +19,10 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
+      <label class="control-label subscribe-label" for="subscribe-email">
+        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this dataset or log in and follow this dataset." data-toggle="tooltip"></i>
+        {{ _(' Sign up for email updates:') }}
+      </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
           <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address"  required />

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -19,9 +19,10 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label" for="subscribe-email" title="Receive email updates for this dataset without needing to login." aria-label="Receive email updates for this dataset without needing to login.">
-        {{ _('Sign up for email updates') }}
-      </label>
+      <label class="control-label"
+             for="subscribe-email"
+             title="Receive email updates for this dataset without needing to login."
+             aria-label="Receive email updates for this dataset without needing to login.">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
           <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address"  required />

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -20,7 +20,7 @@
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label subscribe-label" for="subscribe-email">
-        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this dataset or log in and follow this dataset." data-toggle="tooltip"></i>
+        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this dataset or log in to follow." data-toggle="tooltip"></i>
         {{ _(' Sign up for email updates:') }}
       </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -19,9 +19,8 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label subscribe-label" for="subscribe-email">
-        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this dataset or log in to follow." data-toggle="tooltip"></i>
-        {{ _(' Sign up for email updates:') }}
+      <label class="control-label" for="subscribe-email" title="Receive email updates for this dataset without needing to login." aria-label="Receive email updates for this dataset without needing to login.">
+        {{ _('Sign up for email updates') }}
       </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -19,7 +19,10 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label" for="subscribe-email">{{ _('Sign up for email updates') }}</label>
+      <label class="control-label subscribe-label" for="subscribe-email">
+        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this organization or log in and follow this dataset." data-toggle="tooltip"></i>
+        {{ _('Sign up for email updates:') }}
+      </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
           <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" required />

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -19,9 +19,10 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label" for="subscribe-email" title="Receive email updates for this organization without needing to login." aria-label="Receive email updates for this organization without needing to login.">
-        {{ _('Sign up for email updates') }}
-      </label>
+      <label class="control-label"
+             for="subscribe-email"
+             title="Receive email updates for this organization without needing to login."
+             aria-label="Receive email updates for this organization without needing to login.">{{ _('Sign up for email updates') }}</label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->
           <input id="subscribe-email" type="email" name="email" class="form-control input-small" value="" placeholder="Email Address" required />

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -20,7 +20,7 @@
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
       <label class="control-label subscribe-label" for="subscribe-email">
-        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this organization or log in and follow this dataset." data-toggle="tooltip"></i>
+        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this organization or log in to follow." data-toggle="tooltip"></i>
         {{ _('Sign up for email updates:') }}
       </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -19,9 +19,8 @@
     <div class="nums">
       {% import 'macros/form.html' as form %}
       <!-- {{ form.errors(error_summary) }} -->
-      <label class="control-label subscribe-label" for="subscribe-email">
-        <i class="fa fa-question-circle icon-question-sign muted" title="Receive email updates for this organization or log in to follow." data-toggle="tooltip"></i>
-        {{ _('Sign up for email updates:') }}
+      <label class="control-label" for="subscribe-email" title="Receive email updates for this organization without needing to login." aria-label="Receive email updates for this organization without needing to login.">
+        {{ _('Sign up for email updates') }}
       </label>
       <form method='post' action="{{ h.url_for('/subscribe/signup') }}" id="subscribe-form" enctype="multipart/form-data" class="form-inline">
         <!-- (Bootstrap 3) <div class="form-group input-group-sm"> -->


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-2170](https://opengovinc.atlassian.net/browse/ESN-2170)

## Description
<!--- Describe these changes in detail --->
This PR updates the extension to include an info button that states the purpose of the form and lets users know they could also use the follow feature if they have an account.

## Test Procedure
<!--- List the steps involved to test the changes --->
**UI Testing**
1. Checkout the branch for this PR and run `python setup.py develop`
2. In your ini:
 - Enable the following plugins
```
chhs_schema
scheming_datasets
```
3. Checkout the `chhs` branch in `ckanext-og_theme` and run `python setup.py develop`.
4. Visit the following pages NOT LOGGED into the Open Data portal:
 - Any dataset page
 - Any group's page
 - Any organization's
and ensure the page looks like the following screenshots.


### Info text for datasets
![Screen Shot 2021-04-26 at 1 00 29 PM](https://user-images.githubusercontent.com/49450112/116123407-f7edf280-a690-11eb-9ee8-adbce1991db0.png)



### Info text for organization
![Screen Shot 2021-04-26 at 1 00 53 PM](https://user-images.githubusercontent.com/49450112/116123347-e73d7c80-a690-11eb-8cc9-3457ce6853c7.png)



### Info text for groups
![Screen Shot 2021-04-26 at 1 00 41 PM](https://user-images.githubusercontent.com/49450112/116123481-0a682c00-a691-11eb-842c-501c4fe1354c.png)

