### PR TITLE
[ESN-2170] Add Info Text to Follow Button

### DIFF
--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -13,7 +13,9 @@
 {% endblock %}
 {% block follow %}
   {% if c.user %}
-    {{ super() }}
+    <div class="follow_button" title="Follow this group to receive email updates." aria-label="Follow this group to receive email updates.">
+      {{ h.follow_button('group', group.id) }}
+    </div>
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
     <div class="nums">

--- a/ckanext/subscribe/templates/group/snippets/info.html
+++ b/ckanext/subscribe/templates/group/snippets/info.html
@@ -13,7 +13,7 @@
 {% endblock %}
 {% block follow %}
   {% if c.user %}
-    <div class="follow_button" title="Follow this group to receive email updates." aria-label="Follow this group to receive email updates.">
+    <div class="follow_button" title="Follow to be notified of changes to this group and receive email updates if enabled in user settings." aria-label="Follow to be notified of changes to this group and receive email updates if enabled in user settings.">
       {{ h.follow_button('group', group.id) }}
     </div>
   {% else %}

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -13,7 +13,11 @@
 {% endblock %}
 {% block follow_button %}
   {% if c.user %}
-    {{ super() }}
+    {% if not hide_follow_button %}
+      <div class="follow_button" title="Follow this dataset to receive email updates." aria-label="Follow this dataset to receive email updates.">
+        {{ h.follow_button('dataset', pkg.id) }}
+      </div>
+      {% endif %}
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
     <div class="nums">

--- a/ckanext/subscribe/templates/package/snippets/info.html
+++ b/ckanext/subscribe/templates/package/snippets/info.html
@@ -14,7 +14,7 @@
 {% block follow_button %}
   {% if c.user %}
     {% if not hide_follow_button %}
-      <div class="follow_button" title="Follow this dataset to receive email updates." aria-label="Follow this dataset to receive email updates.">
+      <div class="follow_button" title="Follow to be notified of changes to this dataset and receive email updates if enabled in user settings." aria-label="Follow to be notified of changes to this dataset and receive email updates if enabled in user settings.">
         {{ h.follow_button('dataset', pkg.id) }}
       </div>
       {% endif %}

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -13,7 +13,9 @@
 {% endblock %}
 {% block follow %}
   {% if c.user %}
-    {{ super() }}
+    <div class="follow_button" title="Follow this organization to receive email updates." aria-label="Follow this organization to receive email updates.">
+       {{ h.follow_button('group', organization.id) }}
+    </div> 
   {% else %}
     {% resource 'subscribe/subscribe.css' %}
     <div class="nums">

--- a/ckanext/subscribe/templates/snippets/organization.html
+++ b/ckanext/subscribe/templates/snippets/organization.html
@@ -13,7 +13,7 @@
 {% endblock %}
 {% block follow %}
   {% if c.user %}
-    <div class="follow_button" title="Follow this organization to receive email updates." aria-label="Follow this organization to receive email updates.">
+    <div class="follow_button" title="Follow to be notified of changes to this organization and receive email updates if enabled in user settings." aria-label="Follow to be notified of changes to this organization and receive email updates if enabled in user settings.">
        {{ h.follow_button('group', organization.id) }}
     </div> 
   {% else %}


### PR DESCRIPTION
<!--- Title Link to Jira Ticket - UPDATE WITH YOUR TICKET TAG in name and url --->
## [ESN-2170](https://opengovinc.atlassian.net/browse/ESN-2170)

## Description
<!--- Describe these changes in detail --->
This PR adds info text to the follow button to let users know they will receive email updates if they follow the dataset, group, or organization. This is based on CHHS's feedback.

## Test Procedure
<!--- List the steps involved to test the changes --->
**UI Testing**
1. Checkout the branch for this PR and run `python setup.py develop`
2. In your ini:
 - Enable the following plugins
```
chhs_schema
scheming_datasets
```
3. Checkout the `chhs` branch in `ckanext-og_theme` and run `python setup.py develop`.
4. Visit the following pages NOT LOGGED into the Open Data portal:
 - Any dataset page
 - Any group's page
 - Any organization's
and ensure the page looks like the following screenshots.


### Info text for datasets
![Screen Shot 2021-05-10 at 4 04 06 PM](https://user-images.githubusercontent.com/49450112/117717972-7ecebf00-b1a9-11eb-93a7-fef670cb3dfa.png)




### Info text for organization
![Screen Shot 2021-05-10 at 4 04 34 PM](https://user-images.githubusercontent.com/49450112/117718012-88582700-b1a9-11eb-9f80-5c4581df0dd2.png)





### Info text for groups
![Screen Shot 2021-05-10 at 4 04 46 PM](https://user-images.githubusercontent.com/49450112/117718022-8c844480-b1a9-11eb-865b-454bcf16a5e9.png)



