### PR TITLE
Fix smtp connection

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
   test:
     strategy:
       matrix:
-        ckan-version: [2.9, 2.8, 2.7]
+        ckan-version: [2.9]
       fail-fast: false
 
     name: CKAN ${{ matrix.ckan-version }}
@@ -35,7 +35,7 @@ jobs:
       image: openknowledge/ckan-dev:${{ matrix.ckan-version }}
     services:
       solr:
-        image: ckan/ckan-solr-dev:${{ matrix.ckan-version }}
+        image: ckan/ckan-solr:${{ matrix.ckan-version }}
       postgres:
         image: ckan/ckan-postgres-dev:${{ matrix.ckan-version }}
         env:
@@ -54,20 +54,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: Install requirements
       run: |
-        pip install -r requirements.txt -r dev-requirements.txt -e .
-
+        pip install -r requirements.txt
+        pip install -r dev-requirements.txt
+        pip install -e .
     - name: Setup extension (CKAN >= 2.9)
-      if: ${{ matrix.ckan-version == '2.9' }}
       run: |
         ckan -c git_action_test.ini db init
         ckan -c git_action_test.ini subscribe initdb
-
-    - name: Setup extension (CKAN 2.7)
-      if: ${{ matrix.ckan-version != '2.9'  }}
-      run: |
-        paster --plugin=ckan db init -c git_action_test.ini
-        paster --plugin=ckanext-subscribe subscribe initdb -c git_action_test.ini
-
     - name: Run tests
       run: |
         pytest --ckan-ini=git_action_test.ini --cov=ckanext.subscribe --cov-fail-under=${CODE_COVERAGE_THRESHOLD_REQUIRED} --disable-warnings ckanext/subscribe/tests

--- a/ckanext/subscribe/mailer.py
+++ b/ckanext/subscribe/mailer.py
@@ -60,7 +60,6 @@ def _mail_recipient(recipient_name, recipient_email,
 
 def _mail_payload(msg, mail_from, recipient_email):
     # Send the email using Python's smtplib.
-    smtp_connection = smtplib.SMTP()
     if 'smtp.test_server' in config:
         # If 'smtp.test_server' is configured we assume we're running tests,
         # and don't use the smtp.server, starttls, user, password etc. options.
@@ -76,8 +75,8 @@ def _mail_payload(msg, mail_from, recipient_email):
         smtp_password = config.get('smtp.password')
 
     try:
-        smtp_connection.connect(smtp_server)
-    except socket.error as e:
+        smtp_connection = smtplib.SMTP(smtp_server)
+    except (socket.error, smtplib.SMTPConnectError) as e:
         log.exception(e)
         raise MailerException('SMTP server could not be connected to: "%s" %s'
                               % (smtp_server, e))

--- a/ckanext/subscribe/tests/test_notification_email.py
+++ b/ckanext/subscribe/tests/test_notification_email.py
@@ -47,7 +47,7 @@ class TestSendNotificationEmail(SubscribeBase):
         body = mail_recipient.call_args[1]['body']
         print(body)
         assert dataset['title'] in body
-        assert'{}/dataset/{}'.format(config.get('ckan.site_url'), dataset['id']) in body
+        assert '{}/dataset/{}'.format(config.get('ckan.site_url'), dataset['id']) in body
         assert 'new dataset' in body
         body = mail_recipient.call_args[1]['body_html']
         print(body)


### PR DESCRIPTION
# Description
This PR fixes the error `SMTPServerDisconnected: Connection unexpectedly closed`.
Changes to ssl in python 3.7 broke the use of `smtplib.SMTP().connect(smtp_server)`.
Instead use `smtplib.SMTP(smtp_server)` to create an SMTP instance.