### PR TITLE
set default to daily emails when subscribing

### DIFF
--- a/ckanext/subscribe/action.py
+++ b/ckanext/subscribe/action.py
@@ -51,7 +51,7 @@ def subscribe_signup(context, data_dict):
 
     data = {
         'email': data_dict['email'],
-        'frequency': data_dict.get('frequency', Frequency.IMMEDIATE.value),
+        'frequency': data_dict.get('frequency', Frequency.DAILY.value),
     }
     if data_dict.get('dataset_id'):
         data['object_type'] = 'dataset'


### PR DESCRIPTION
customers can later override/customize, but, by default, when they subscribe, make it daily
![image](https://github.com/user-attachments/assets/ea15d228-965d-4c37-b11d-cc3e69d8109a)
